### PR TITLE
textlintで表記揺れを正すように設定した

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -5,6 +5,9 @@
         "periodMark": "．"
       }
     },
-    "spellcheck-tech-word": true
+    "spellcheck-tech-word": true,
+    "prh": {
+      "rulePaths": ["prh.yml"]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "textlint": "https://yamaokaya.ml/textlint.tgz",
     "textlint-rule-preset-ja-technical-writing": "^2.0.0",
+    "textlint-rule-prh": "^5.0.1",
     "textlint-rule-spellcheck-tech-word": "^5.0.0"
   }
 }

--- a/prh.yml
+++ b/prh.yml
@@ -1,0 +1,58 @@
+version: 1
+rules:
+
+  # 用語
+
+  - expected: 食生活
+    patterns:
+      - 食習慣
+
+  - expected: 食事
+    patterns:
+      - 料理
+
+  - expected: ユーザ
+    patterns:
+      - ユーザー
+
+  - expected: Web
+    patterns:
+      - ウェブ
+
+  - expected: テレビ
+    patterns:
+      - TV
+
+  - expected: メッセージ
+    patterns:
+      - コメント
+
+  # 表現
+
+  - expected: 本節では
+    patterns:
+      - ここでは
+
+  - expected: 明らかになっ$1
+    patterns:
+      - /分かっ(た|ている|てきた)/
+
+  - expected: できる
+    patterns:
+      - 出来る
+
+  - expected: の方
+    patterns:
+      - の人
+
+  # 記号
+
+  - expected: ．
+    patterns:
+       - 。
+       - "."
+
+  - expected: ，
+    patterns:
+      - 、
+      - ","

--- a/yarn.lock
+++ b/yarn.lock
@@ -1598,7 +1598,7 @@ textlint-rule-prh@^3.1.1:
     textlint-rule-helper "^2.0.0"
     untildify "^3.0.2"
 
-textlint-rule-prh@^5.0.0:
+textlint-rule-prh@^5.0.0, textlint-rule-prh@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/textlint-rule-prh/-/textlint-rule-prh-5.0.1.tgz#bab66be6b03258880f3fbf466b689ed2ff379b0c"
   dependencies:


### PR DESCRIPTION
textlint-rule-prhを導入して手動でルールを記述することで、表記揺れの検出・及び修正ができるようにした。