### PR TITLE
現段階で正常に動作しないルールを除外した

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,9 +1,8 @@
 {
   "rules": {
     "preset-ja-technical-writing": {
-      "ja-no-mixed-period": {
-        "periodMark": "．"
-      }
+      "ja-no-mixed-period": false,
+      "sentence-length": false
     },
     "spellcheck-tech-word": true,
     "prh": {

--- a/prh.yml
+++ b/prh.yml
@@ -50,9 +50,7 @@ rules:
   - expected: ．
     patterns:
        - 。
-       - "."
 
   - expected: ，
     patterns:
       - 、
-      - ","


### PR DESCRIPTION
TeXファイルのパースが上手く行えていないので，以下のルールが正常に動かずレビューがうるさい．
* preset-ja-technical-writing/ja-no-mixed-period
* preset-ja-technical-writing/sentence-length
なので一旦除外することとした．

TeXファイルのパースが上手くいくようになれば戻す．

close #36 